### PR TITLE
Chemmaster update.

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -235,7 +235,7 @@
 				return
 
 			var/amount_per_pill = reagents.total_volume/count
-			if (amount_per_pill > 60) amount_per_pill = 60
+			if (amount_per_pill > 100) amount_per_pill = 100
 
 			var/name = sanitizeSafe(input(usr,"Name:","Name your pill!","[reagents.get_master_reagent_name()] ([amount_per_pill] units)"), MAX_NAME_LEN)
 

--- a/nano/templates/chem_master.tmpl
+++ b/nano/templates/chem_master.tmpl
@@ -64,7 +64,7 @@
 		{{if !data.condi}}
 			<hr>
 			<div class='item'>
-				{{:helper.link('Create pill (60 units max)', null, {'createpill' : 1})}}
+				{{:helper.link('Create pill (100 units max)', null, {'createpill' : 1})}}
 				{{:helper.link('Create multiple pills', null, {'createpill_multiple' : 1})}}
 				{{:helper.link('Create bottle (60 units max)', null, {'createbottle' : 1})}}
 				{{:helper.link('Create patch (60 units max)', null, {'createpatch' : 1})}}


### PR DESCRIPTION
## About The Pull Request

Changes the maximum units you can put into a pill using the chemmaster from 60 units to 100.

## Why It's Good For The Game

More chemical/medication formulas! Allows for greater diversity and creativity not only when working in the hospital but for businesses in future that plan to work in pharmacy and make their own brand. Other servers have a number absurdly higher than this (300, 500 etc.) and I think this change just allows for more possibilities and potentially makes the life of hospital staff easier.

## Changelog
:cl:
tweak: Chemmaster maximum units per pill changed from 60u to 100u
/:cl:
