### PR TITLE
Update material_recipes.dm

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -244,6 +244,7 @@
 
 /material/wood/generate_recipes()
 	..()
+	recipes += new/datum/stack_recipe("ore box", /obj/structure/ore_box, 25, time = 10)
 	recipes += new/datum/stack_recipe("oar", /obj/item/weapon/oar, 2, time = 30, supplied_material = "[name]")
 	recipes += new/datum/stack_recipe("boat", /obj/vehicle/boat, 20, time = 10 SECONDS, supplied_material = "[name]")
 	recipes += new/datum/stack_recipe("dragon boat", /obj/vehicle/boat/dragon, 50, time = 30 SECONDS, supplied_material = "[name]")


### PR DESCRIPTION
## About The Pull Request

Adds ore boxes as a craftable item via wood stacks. Requires 25 wood planks.

## Why It's Good For The Game

Currently difficult to obtain and the ones you can obtain aren't persistent. Added this upon a players request, and it seems like a good idea.

## Changelog
:cl:
add: Added ore boxes as a craftable item via wood stacks. 
/:cl: