### PR TITLE
Bount-T removal

### DIFF
--- a/code/datums/supplypacks/circuits.dm
+++ b/code/datums/supplypacks/circuits.dm
@@ -113,12 +113,12 @@
 	containertype = /obj/structure/closet/crate
 	containername = "Token Dispenser Circuit"
 
-/datum/supply_pack/circuits/bounty_machine
+/* /datum/supply_pack/circuits/bounty_machine
 	contains = list(/obj/item/weapon/circuitboard/bounty_machine)
 	name = "bounty-T Circuit"
 	cost = 10000
 	containertype = /obj/structure/closet/crate
-	containername = "Bounty Machine Circuit"
+	containername = "Bounty Machine Circuit" */
 
 /datum/supply_pack/circuits/forensics
 	contains = list(


### PR DESCRIPTION

## About The Pull Request

Could finally be assed to remove the bounty circuit from the cargo console. Removes nothing else, should just make them unavailable now.

## Why It's Good For The Game
No inflation or moneyfarms or bans as a result of using bounties when you're not supposed to.

## Changelog
:cl:
tweak: Commented out bounty machine circuits in cargo.

/:cl: