### PR TITLE
Update admins.txt

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -5,7 +5,5 @@
 # Ranks can be anything defined in admin_ranks.txt           ~Carn   #
 ######################################################################
 
-farfromthetsar - host
-woodentucker - gamemaster
-Jeff_139 - Moderator 
+farfromthetsar - host 
 WolfFang55 - Moderator


### PR DESCRIPTION
## About The Pull Request

These two probably shouldn't be admin anymore. One of them frequently abuses their admin, and the other ignores it. Besides, Wooden's supposed to be an advisor anyway- he should've had his staff removed ages ago! 

## Why It's Good For The Game

No longer have to deal with an admin who behaves like a fascist or have to deal with explosions in future rounds! This fix was urgently needed. Now we need to fix our coder situation and economy, but that might be a more difficult task as that'd require us to remove the narcissism code modules which are deeply embedded within.


## Changelog
fix: fixed a few things
/:cl: