### PR TITLE
Makes the xenoarch multitool actually printable

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1897,7 +1897,7 @@ CIRCUITS BELOW
 	sort_string = "HABQB"
 	price = 300
 
-/datum/design/obj/item/device/xenoarch_multi_tool
+/datum/design/item/device/xenoarch_multi_tool
 	name = "xenoarcheology multitool"
 	id = "xenoarch_multitool"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the xenoarch multitool actually printable by removing '/obj/' from '/datum/design/obj/item/device/xenoarch_multi_tool' in the protolathe designs.
(This is tested, I made sure to double check since it sounds like making that change might mess up the item)

## Why It's Good For The Game

Makes a useful item actually appear in the protolathe like it (seems) to be intended.

## Changelog
:cl: me8my
fix: Fixed the xenoarch multitool not appearing in the protolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->