### PR TITLE
Allows the circuit imprinter to put prices on printed circuits.

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -204,8 +204,17 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		reagents.remove_reagent(C, D.chemicals[C] * mat_efficiency)
 
 	if(D.build_path)
-		var/obj/new_item = D.Fabricate(src, src)
-		new_item.loc = loc
+		var/obj/item/new_item = D.Fabricate(src, src)
+		new_item.tagged_price = D.price
+		if(D.protected)
+			var/obj/item/weapon/redemption_box/r_box = new /obj/item/weapon/redemption_box(loc)
+			r_box.receiving_department = DEPT_RESEARCH
+			if(LAZYLEN(new_item.origin_tech))
+				r_box.origin_tech = new_item.origin_tech
+				r_box.name += " ([new_item.name])"
+			new_item.forceMove(r_box)
+		else
+			new_item.loc = loc
 		if(mat_efficiency != 1) // No matter out of nowhere
 			if(new_item.matter && new_item.matter.len > 0)
 				for(var/i in new_item.matter)


### PR DESCRIPTION
## About The Pull Request

Ports the capability to price tag printed objects from the protolathe into the circuit imprinter.

## Why It's Good For The Game

This would allow RnD to have a baseline price to sell unprotected circuits for, and allow protecting (redemption box) circuits. (AI core and lawset boards are already set as protected)

## Changelog
:cl: me8my
fix: Ported the protolathe's integrated price tagger into the circuit imprinter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->