### PR TITLE
Rearranges police equipemnt so communicator correctly spawns.

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -71,14 +71,15 @@
 	l_pocket = /obj/item/device/flash
 	id_type = /obj/item/weapon/card/id/security/officer
 	pda_type = /obj/item/device/pda/security
-	r_pocket = /obj/item/weapon/reagent_containers/spray/pepper
+	pda_slot = slot_r_store // puts communicator in right pocket
 	suit = /obj/item/clothing/suit/storage/vest/officer
 	belt = /obj/item/weapon/storage/belt/security
 	backpack_contents = list(/obj/item/weapon/handcuffs = 2,
 	/obj/item/clothing/accessory/permit/gun/tier_four = 1,
 	/obj/item/weapon/gun/energy/taser = 1,
 	/obj/item/weapon/cell/device/weapon = 2,
-	/obj/item/clothing/accessory/holster = 1)
+	/obj/item/clothing/accessory/holster = 1,
+	/obj/item/weapon/reagent_containers/spray/pepper = 1)
 
 /decl/hierarchy/outfit/job/security/traffic
 	name = OUTFIT_JOB_NAME("Traffic Warden")


### PR DESCRIPTION
## About The Pull Request

Fixes a bug caused by pull #77.
Moves the pepper spray from the right pocket into the backpack, and sets the right pockets as the slot to spawn the communicator in for the police officer outfit.


## Why It's Good For The Game

Makes cops actually have the communicator they are intended to have.

## Changelog
:cl: me8my55
tweak: Moved police officer's pepper spray from their right pocket into their backpack.
fix: Set the right pocket as the slot to spawn the communicator into for police officers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->