### PR TITLE
Fixed airlocks keeping their entered code when 'lock' is pressed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1067,6 +1067,7 @@ About the new airlock wires panel:
 			if(locked)
 				return
 
+			code = null
 			locked = TRUE
 
 		if(href_list["type"])

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -410,6 +410,7 @@
 			if(locked)
 				return
 
+			code = null
 			locked = TRUE
 
 		if(href_list["type"])


### PR DESCRIPTION
## About The Pull Request

Fixed a bug where airlocks would keep their currently entered code when the 'lock' button is pressed.

## Why It's Good For The Game

Bug fix.

## Changelog
:cl: me8my
fix: Fixed airlock GUI not clearing code when locking.
/:cl: