### PR TITLE
Updates the Jesus event mob

### DIFF
--- a/code/modules/mob/event_mobs.dm
+++ b/code/modules/mob/event_mobs.dm
@@ -13,8 +13,7 @@
 	src.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(src), slot_shoes)
 	src.equip_to_slot_or_del(new /obj/item/clothing/under/pants/baggy/white(src), slot_w_uniform)
 	src.equip_to_slot_or_del(new /obj/item/clothing/suit/kimono(src), slot_wear_suit)
-	src.equip_to_slot_or_del(new /obj/item/weapon/storage/bible/booze(src), slot_r_hand)
-	src.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater(src), slot_l_hand)
+	src.equip_to_slot_or_del(new /obj/item/weapon/card/id/centcom/station(src), slot_wear_id)
 	name = "Jesus Christ"
 	real_name = "Jesus Christ"
 
@@ -26,4 +25,4 @@
 	src.see_in_dark = 8
 	src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	src.update_mutations()
-	src.mind.special_role = "Jesus"
+	//src.mind.special_role = "Jesus" // it appears this is causing New() to stop running due to jesus not having a mind on spawn - wolf


### PR DESCRIPTION
## About The Pull Request

Removes the Bible and Holy water from Jesus's hand slots, as he just drops them immediately after spawning anyways.
Adds a Centcomm ID to Jesus's ID card slot so it doesn't need to be spawned in most of the times we use Jesus.
Commented out a line that just caused the New() proc to stop running due to Jesus not having a mind on spawn. (Might not be doing anything bad anyways, but might as well fix it)

## Why It's Good For The Game

Makes Jesus easier to use for admins, and makes them a bit less buggy.

## Changelog
:cl: Me8my
add: Added a ID to Jesus
del: Took away Jesus's Bible and Holy Water
code: Commented a line of code that caused a runtime error 
/:cl: